### PR TITLE
Various Typo FIxes

### DIFF
--- a/commands/addallbans.js
+++ b/commands/addallbans.js
@@ -2,7 +2,7 @@ const { MessageEmbed } = require('discord.js');
 
 const Ban = require('../database/models/Ban');
 
-const errHander = (err) => {
+const errHandler = (err) => {
   console.error('ERROR:', err);
 };
 
@@ -44,21 +44,21 @@ module.exports.run = async (client, message, args, config) => {
             const [banEntry] = await Ban.findOrCreate({
               where: { userID, serverID },
               defaults: { reason: fixedReason, userTag, userBanned },
-            }).catch(errHander);
+            }).catch(errHandler);
             if (!banEntry.isNewRecord) {
               Ban.update({ reason: fixedReason, userBanned },
                 { where: { userID, serverID } })
-                .catch(errHander);
+                .catch(errHandler);
             }
           });
         })
         .then(() => msg.edit({ embed: new MessageEmbed().setAuthor('Done!', 'https://cdn0.iconfinder.com/data/icons/small-n-flat/24/678134-sign-check-512.png') }))
-        .catch(errHander);
-    }).catch(errHander);
+        .catch(errHandler);
+    }).catch(errHandler);
 };
 
 module.exports.help = {
   name: 'addallbans',
   usage: 'SERVERID',
-  desc: 'Adds all bans drom the current server its beeing used in.',
+  desc: 'Adds all bans from the current server its being used in.',
 };

--- a/commands/checkallusers.js
+++ b/commands/checkallusers.js
@@ -70,7 +70,7 @@ module.exports.run = async (client, message, args, config) => {
         return postBans(allBans, config, message);
       default:
         // wrong reaction
-        return messageFail(message, 'Please only choose one othe the two options! Try again.');
+        return messageFail(message, 'Please only choose one of the two options! Try again.');
     }
   });
   reactionCollector.on('end', () => confirmMessage.delete());

--- a/commands/disabled/UserPunnishmentTicker.js
+++ b/commands/disabled/UserPunnishmentTicker.js
@@ -18,7 +18,7 @@ module.exports = sequelize.define('UserPunishmentTicker', {
     type: Sequelize.STRING(30),
     allowNull: false,
   },
-  ammountLeft: {
+  amountLeft: {
     type: Sequelize.INTEGER,
     allowNull: false,
   },

--- a/commands/disabled/punish-handler.js
+++ b/commands/disabled/punish-handler.js
@@ -15,7 +15,7 @@ function CommandUsage(prefix, cmdName, subcmd) {
 // check if server has feature enabled.
 async function checkFeature(serverID) {
   const found = await ServerSetting.findOne({ where: { serverID, pointsSystemEnabled: true } })
-    .catch(errHander);
+    .catch(errHandler);
   return found;
 }
 

--- a/commands/disabled/punishsettings-handler.js
+++ b/commands/disabled/punishsettings-handler.js
@@ -9,7 +9,7 @@ function CommandUsage(prefix, cmdName, subcmd) {
 // check if server has feature enabled.
 async function checkFeature(serverID) {
   const found = await ServerSetting.findOne({ where: { serverID, pointsSystemEnabled: true } })
-    .catch(errHander);
+    .catch(errHandler);
   return found;
 }
 

--- a/commands/guild.js
+++ b/commands/guild.js
@@ -21,7 +21,7 @@ async function addServer(ParticipatingServer, serverID, logChannelID, teamRoleID
 async function removeServer(ParticipatingServer, serverID) {
   const success = await ParticipatingServer.update({ active: false },
     { where: { serverID, active: true } })
-    .catch(errHander);
+    .catch(errHandler);
   return success[0];
 }
 
@@ -59,7 +59,7 @@ module.exports.run = async (client, message, args, config) => {
         return;
       }
       if (!await client.functions.get('FUNC_checkID').run(logChannelID, client, 'channel')) {
-        messageFail(message, `The channel with the ID \`${logChannelID}\` doesnt exist!`);
+        messageFail(message, `The channel with the ID \`${logChannelID}\` doesn't exist!`);
         return;
       }
       if (!await client.functions.get('FUNC_checkID').run(serverID, client, 'server')) {
@@ -114,7 +114,7 @@ module.exports.run = async (client, message, args, config) => {
         Log Channel: <#${serverFound.logChannelID}> (\`${serverFound.logChannelID}\`)
         Team Role ID: \`${serverFound.teamRoleID}\`
         Submitted Bans: \`${await getBanCount(serverID)}\`
-        Is server part of Assisioation: \`${serverFound.active}\``;
+        Is server apart of Association: \`${serverFound.active}\``;
         if (serverFound.active) content += `\nParticipating Server since \`${serverFound.updatedAt}\``;
         messageSuccess(message, content);
       } else {

--- a/commands/lookup.js
+++ b/commands/lookup.js
@@ -15,7 +15,7 @@ const UserIDAssociation = require('../database/models/UserIDAssociation');
 // looksup usertag in list if recorded
 async function checkTag(userTag) {
   const found = await UserIDAssociation.findOne({ where: { userTag } })
-    .catch(errHander);
+    .catch(errHandler);
   return found;
 }
 
@@ -166,5 +166,5 @@ module.exports.run = async (client, message, args, config) => {
 module.exports.help = {
   name: 'lookup',
   usage: 'USERID|USERTAG|USERMENTION|USERSEARCH',
-  desc: 'Uses the Discord API to lookup userinformaiton',
+  desc: 'Uses the Discord API to lookup user information',
 };

--- a/commands/warn.js
+++ b/commands/warn.js
@@ -5,13 +5,13 @@ const Warn = require('../database/models/Warn');
 // adds a Warn to the warning table
 async function addWarn(serverID, userID, reason) {
   await Warn.create({ userID, serverID, reason })
-    .catch(errHander);
+    .catch(errHandler);
 }
 
 // edits a Warn to the warning table
 async function editWarn(warnID, reason) {
   Warn.update({ reason }, { where: { warnID } })
-    .catch(errHander);
+    .catch(errHandler);
 }
 
 // checks if server is partisipating server
@@ -48,7 +48,7 @@ function checkforInfectedGuilds(client, guild, userID, warnReason) {
 
 async function getWarning(warnID) {
   const found = await Warn.findOne({ where: { warnID } })
-    .catch(errHander);
+    .catch(errHandler);
   return found;
 }
 

--- a/database/models/PunishmentLevel.js
+++ b/database/models/PunishmentLevel.js
@@ -13,5 +13,5 @@ module.exports = sequelize.define('PunishmentLevel', {
     type: Sequelize.TEXT('tiny'),
     allowNull: false,
   },
-  ammount: Sequelize.INTEGER,
+  amount: Sequelize.INTEGER,
 });

--- a/functions/EVENT_guildBanAdd.js
+++ b/functions/EVENT_guildBanAdd.js
@@ -4,7 +4,7 @@ const Ban = require('../database/models/Ban');
 
 const config = require('../config/main.json');
 
-const errHander = (err) => {
+const errHandler = (err) => {
   console.error('ERROR:', err);
 };
 
@@ -53,13 +53,13 @@ module.exports.run = async (guild, user) => {
       const [banEntry] = await Ban.findOrCreate({
         where: { userID, serverID },
         defaults: { userTag, reason: fixedReason, userBanned },
-      }).catch(errHander);
+      }).catch(errHandler);
       // check if entry is already on DB
       if (await !banEntry.isNewRecord) {
         // update DB entry
         Ban.update({ reason: fixedReason, userTag, userBanned },
           { where: { userTag, userID, serverID } })
-          .catch(errHander);
+          .catch(errHandler);
       }
       banReason = fixedReason;
       const bannedGuild = await getServerEntry(user.client, serverID);

--- a/functions/EVENT_guildBanRemove.js
+++ b/functions/EVENT_guildBanRemove.js
@@ -1,7 +1,7 @@
 const Ban = require('../database/models/Ban');
 
 // error-handler for event-function
-const errHander = (err) => {
+const errHandler = (err) => {
   console.error('ERROR:', err);
 };
 
@@ -13,7 +13,7 @@ module.exports.run = async (guild, user) => {
   // update ban-DB entry
   Ban.update({ userBanned },
     { where: { userID, serverID } })
-    .catch(errHander);
+    .catch(errHandler);
 };
 
 module.exports.help = {

--- a/functions/EVENT_guildMemberAdd.js
+++ b/functions/EVENT_guildMemberAdd.js
@@ -7,7 +7,7 @@ const Warn = require('../database/models/Warn');
 const config = require('../config/main.json');
 
 // error Handler
-const errHander = (err) => {
+const errHandler = (err) => {
   console.error('ERROR:', err);
 };
 
@@ -22,7 +22,7 @@ function findLogChannel(client, logChannelID) {
 }
 
 // send message when user is banned
-async function sendMessage(client, serverID, userID, userTag, ammount) {
+async function sendMessage(client, serverID, userID, userTag, amount) {
   const server = await getServerEntry(client, serverID);
   const logChannelID = server.logChannelID;
   const logChannel = await findLogChannel(client, logChannelID);
@@ -31,7 +31,7 @@ async function sendMessage(client, serverID, userID, userTag, ammount) {
     .run(client.user, logChannel,
       `tag: \`${userTag}\`
       ID: \`${userID}\`
-      bans and warns: \`${ammount}\`
+      bans and warns: \`${amount}\`
       For more information use \`${config.prefix}lookup ${userID}\``,
       `Banned user joined '${serverName}'`,
       16739072, false);
@@ -43,11 +43,11 @@ module.exports.run = async (client, member) => {
   // check if user is banned on some server
   const [serverID, userID, userTag] = [member.guild.id, member.id, member.user.tag];
   // get all bans and warnings the joined user has
-  const userBans = await Ban.findAll({ where: { userID } }).catch(errHander);
-  const userWarns = await Warn.findAll({ where: { userID } }).catch(errHander);
+  const userBans = await Ban.findAll({ where: { userID } }).catch(errHandler);
+  const userWarns = await Warn.findAll({ where: { userID } }).catch(errHandler);
   // calculate sum and check if sum is still 0
-  const overallAmmount = userBans.length + userWarns.length;
-  if (overallAmmount !== 0) sendMessage(client, serverID, userID, userTag, overallAmmount);
+  const overallamount = userBans.length + userWarns.length;
+  if (overallamount !== 0) sendMessage(client, serverID, userID, userTag, overallamount);
 };
 
 module.exports.help = {

--- a/functions/FUNC_invalidCMD.js
+++ b/functions/FUNC_invalidCMD.js
@@ -1,5 +1,5 @@
 module.exports.run = async (message, subcmd) => {
-  const confusResponses = [
+  const confusedResponses = [
     'You... what, now?',
     'Pardon me?',
     'Hah, yeah... what?',
@@ -7,14 +7,14 @@ module.exports.run = async (message, subcmd) => {
     'Come again?',
     'Maybe you should try something else there, buddy.',
     `I tried to understand \`${subcmd}\`, trust me, but I just cannot.`,
-    `Invalid comamnd: \`${subcmd}\` 💩`,
+    `Invalid command: \`${subcmd}\` 💩`,
     `Sorry, I don't know this command -  \`${subcmd}\``,
     `Eh? Do you speak my language? Because I don't know \`${subcmd}\`...`,
     'I don\'t know what to do... UwU',
   ];
 
-  const randomChoice = Math.floor(Math.random() * confusResponses.length);
-  message.channel.send(confusResponses[randomChoice]);
+  const randomChoice = Math.floor(Math.random() * confusedResponses.length);
+  message.channel.send(confusedResponses[randomChoice]);
   message.react('❌');
 };
 

--- a/functions/FUNC_userTagRecord.js
+++ b/functions/FUNC_userTagRecord.js
@@ -9,7 +9,7 @@ module.exports.run = async (userID, userTag) => {
     where: { userID },
     defaults: { userTag },
   })
-    .catch(errHander);
+    .catch(errHandler);
   cachedUsers.push(userID);
 };
 

--- a/functions/GLBLFUNC_errHander.js
+++ b/functions/GLBLFUNC_errHander.js
@@ -1,5 +1,5 @@
-global.errHander = (err) => console.error('ERROR:', err);
+global.errHandler = (err) => console.error('ERROR:', err);
 
 module.exports.help = {
-  name: 'GLBLFUNC_errHander',
+  name: 'GLBLFUNC_errHandler',
 };

--- a/functions/SETUP_offlineStat.js
+++ b/functions/SETUP_offlineStat.js
@@ -6,7 +6,7 @@ const startupTime = +new Date();
 
 const OfflineStat = require('../database/models/OfflineStat');
 
-const errHander = (err) => {
+const errHandler = (err) => {
   console.error('ERROR:', err);
 };
 
@@ -19,7 +19,7 @@ module.exports.run = async (client, config) => {
     .setColor(4296754)
     .setFooter(client.user.tag, client.user.displayAvatarURL)
     .setTimestamp();
-  const offlineTime = await OfflineStat.findOne({ where: { ID: 1 } }).catch(errHander);
+  const offlineTime = await OfflineStat.findOne({ where: { ID: 1 } }).catch(errHandler);
   if (offlineTime) {
     embed
       .addField('The time the bot was offline:', `${toTime(startupTime - offlineTime.time * 1)}`, false)

--- a/functions/TCKR_offlineStat.js
+++ b/functions/TCKR_offlineStat.js
@@ -2,7 +2,7 @@ const startupTime = +new Date();
 
 const OfflineStat = require('../database/models/OfflineStat');
 
-const errHander = (err) => {
+const errHandler = (err) => {
   console.error('ERROR:', err);
 };
 
@@ -14,9 +14,9 @@ module.exports.run = async (client, config) => {
     // loop db update in 5 sec intervall
     const [offlineStat] = await OfflineStat.findOrCreate({
       where: { ID: 1 }, defaults: { time: startupTime },
-    }).catch(errHander);
+    }).catch(errHandler);
     if (!offlineStat.isNewRecord) {
-      OfflineStat.update({ time: +new Date() }, { where: { ID: 1 } }).catch(errHander);
+      OfflineStat.update({ time: +new Date() }, { where: { ID: 1 } }).catch(errHandler);
     }
   }, 1 * 5000);
 };

--- a/functions/disabled/CMD_punishsettings_enable.js
+++ b/functions/disabled/CMD_punishsettings_enable.js
@@ -8,14 +8,14 @@ function CommandUsage(prefix, cmdName, subcmd) {
 
 // adds server if not existent
 async function createServer(serverID) {
-  const created = await ServerSetting.findOrCreate({ where: { serverID } }).catch(errHander);
+  const created = await ServerSetting.findOrCreate({ where: { serverID } }).catch(errHandler);
   return created;
 }
 
 // checks is server is on list
 async function checkServer(serverID) {
   const found = await ServerSetting.findOne({ where: { serverID } })
-    .catch(errHander);
+    .catch(errHandler);
   return found;
 }
 
@@ -23,7 +23,7 @@ async function checkServer(serverID) {
 async function enablePointsSystem(serverID) {
   const enabled = await ServerSetting.update({ pointsSystemEnabled: true },
     { where: { serverID } })
-    .catch(errHander);
+    .catch(errHandler);
   return enabled;
 }
 
@@ -31,7 +31,7 @@ async function enablePointsSystem(serverID) {
 async function disablePointsSystem(serverID) {
   const disabled = await ServerSetting.update({ pointsSystemEnabled: false },
     { where: { serverID } })
-    .catch(errHander);
+    .catch(errHandler);
   return disabled;
 }
 

--- a/functions/disabled/CMD_punishsettings_forceReason.js
+++ b/functions/disabled/CMD_punishsettings_forceReason.js
@@ -10,7 +10,7 @@ function CommandUsage(prefix, cmdName, subcmd) {
 async function enableForceReason(serverID) {
   const enabled = await ServerSetting.update({ pointsSystemForceReason: true },
     { where: { serverID } })
-    .catch(errHander);
+    .catch(errHandler);
   return enabled;
 }
 
@@ -18,7 +18,7 @@ async function enableForceReason(serverID) {
 async function disableForceReason(serverID) {
   const disabled = await ServerSetting.update({ pointsSystemForceReason: false },
     { where: { serverID } })
-    .catch(errHander);
+    .catch(errHandler);
   return disabled;
 }
 

--- a/functions/disabled/CMD_punishsettings_listSettings.js
+++ b/functions/disabled/CMD_punishsettings_listSettings.js
@@ -5,7 +5,7 @@ const ServerSetting = require('../database/models/ServerSetting');
 // gets server settings
 async function getSettings(serverID) {
   const found = await ServerSetting.findOne({ where: { serverID } })
-    .catch(errHander);
+    .catch(errHandler);
   return found;
 }
 

--- a/migrations/20201010203733-PunishmentLevels.js
+++ b/migrations/20201010203733-PunishmentLevels.js
@@ -12,7 +12,7 @@ module.exports = {
       type: Sequelize.TEXT('tiny'),
       allowNull: false,
     },
-    ammount: Sequelize.INTEGER,
+    amount: Sequelize.INTEGER,
     createdAt: Sequelize.DATE,
     updatedAt: Sequelize.DATE,
   }),

--- a/migrations/20201124014302-UserPunnishmentTickers.js
+++ b/migrations/20201124014302-UserPunnishmentTickers.js
@@ -17,7 +17,7 @@ module.exports = {
       type: Sequelize.STRING(30),
       allowNull: false,
     },
-    ammountLeft: {
+    amountLeft: {
       type: Sequelize.INTEGER,
       allowNull: false,
     },


### PR DESCRIPTION
Fixed various spelling errors throughout much of the bot's user-centered outputs. In regards to the internal typo fixes, I am unsure whether or not you made them intentionally to which they all can be removed from the pull if you find those changes to be damaging. To go into further detail, for the `errHander` to `errhandler` changes, I am not sure whether or not it was intentional or not, however, we can change this if it does negatively impact the bot. For the `ammount` to `amount` changes, *modification of the physical database will be required* as they were used in conjunction with the SQL table handler to which I am assuming the incorrect spelling is currently being used within the database